### PR TITLE
Add a dependency for RUnit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,5 +14,5 @@ Imports: Rcpp (>= 0.12.12), RcppArmadillo, RcppEigen, stats
 LinkingTo: Rcpp, RcppArmadillo, RcppEigen
 biocViews: ImmunoOncology, BatchEffect, Microbiome, Bayesian
 RoxygenNote: 6.0.1
-Suggests: knitr, rmarkdown, BiocGenerics
+Suggests: knitr, rmarkdown, BiocGenerics, RUnit
 VignetteBuilder: knitr


### PR DESCRIPTION
The [checks](https://bioconductor.org/checkResults/3.18/bioc-LATEST/BDMMAcorrect/nebbiolo2-checksrc.html) fail with:

```
ERROR
Running the tests in ‘tests/Test.R’ failed.
Last 13 lines of output:
  
  Attaching package: 'Biobase'
  
  The following object is masked from 'package:MatrixGenerics':
  
      rowMedians
  
  The following objects are masked from 'package:matrixStats':
  
      anyMissing, rowMedians
  
  Error in library("RUnit", quietly = TRUE) : 
    there is no package called 'RUnit'
```